### PR TITLE
Add GitHub Issue Template for Maintainers & Developers #3

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,48 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior
+title: "[BUG] "
+labels: bug
+assignees: ''
+
+---
+
+## 🐛 Bug Description
+
+A clear and concise description of what the bug is.
+
+---
+
+## 🔁 Reproduction Steps
+
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Run '...'
+3. See error
+
+---
+
+## 📷 Screenshots (if applicable)
+
+If applicable, add screenshots to help explain your problem.
+
+---
+
+## 🧪 Expected Behavior
+
+What did you expect to happen instead?
+
+---
+
+## 🧩 Environment
+
+- OS: [e.g. Windows 10, macOS 13]
+- Go Version: `go version`
+- Package: [e.g. tree, graph]
+- Other details:
+
+---
+
+## 📝 Additional Context
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/dev_maintainer_feature.md
+++ b/.github/ISSUE_TEMPLATE/dev_maintainer_feature.md
@@ -1,0 +1,79 @@
+---
+name: New Feature or Improvement (For Maintainers & Developers)
+about: Propose a new feature or improvement for the project (for internal use only)
+title: "[FEATURE/IMPROVEMENT] "
+labels: enhancement
+assignees: ''
+
+---
+
+## ⚠️ Warning
+
+This issue template is **reserved for project maintainers and developers** only.
+If you are a contributor, please use the general issue templates for bug reports or feature requests.
+
+---
+
+## 📁 Tasks
+
+- [ ] Describe the feature or improvement to be added
+- [ ] Identify the problem this feature will address
+- [ ] Provide design considerations and approach
+- [ ] Determine test plan for implementation
+- [ ] Link related issues or PRs
+- [ ] Define acceptance criteria
+- [ ] Plan follow-up tasks (if necessary)
+
+---
+
+## 🚀 Feature/Improvement Description
+
+Provide a clear and concise description of the feature or improvement.
+
+---
+
+## 🧩 Problem Context
+
+Describe the problem that this feature or improvement will address, or explain why this change is needed.
+
+---
+
+## 💡 Design Considerations
+
+- Explain the approach or design for implementing this change.
+- If this is a breaking change, outline how you plan to handle backward compatibility.
+- Provide any diagrams, data flow, or relevant explanations for the proposed solution.
+
+---
+
+## 🧪 Test Plan
+
+- Describe the test strategy and any specific tests you will write.
+- Will you add unit, integration, or system tests?
+- If applicable, explain how you will test the change locally or in CI.
+
+---
+
+## 🔗 Related Issues or PRs
+
+- Link to any related issues or PRs that are relevant.
+- Example: "Closes #3", "Fixes #10"
+
+---
+
+## 🎯 Acceptance Criteria
+
+- A clear and actionable list of requirements to consider this feature complete.
+- Example:
+- [ ] Feature X works as expected
+- [ ] All tests pass
+- [ ] No breaking changes to existing functionality
+
+---
+
+## 🔄 Follow-up Tasks (Optional)
+
+- Any follow-up steps after this issue is resolved.
+- Example:
+- [ ] Update documentation
+- [ ] Communicate with team about the new feature

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,31 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+title: "[FEATURE] "
+labels: enhancement
+assignees: ''
+
+---
+
+## 🚀 Feature Description
+
+Clearly describe the feature you'd like to see implemented.
+
+---
+
+## 🤔 Why Is This Feature Needed?
+
+Explain the motivation behind this feature — what problem does it solve or improve?
+
+---
+
+## 🔗 Related Modules (if any)
+
+- [ ] tree
+- [ ] other: ___
+
+---
+
+## 💡 Additional Notes
+
+Add any other details or ideas here.

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Questions or Help
+    url: https://github.com/tot0p/utils/discussions
+    about: Please ask questions or start discussions here.


### PR DESCRIPTION
## **Description:**

This pull request adds a new GitHub issue template specifically for **maintainers and developers**. The template is designed to standardize the process for proposing new features or improvements internally. 

### **Changes:**

- Created a new issue template: `dev_maintainer_feature.md`.
  - Includes sections for feature description, problem context, design considerations, test plan, related issues, and acceptance criteria.
  - Provides a list of tasks to help guide the development of new features or improvements.
  - Includes a warning to restrict its use to project maintainers and developers only.

- Added a `config.yml` file to configure the behavior of issue templates and provide a contact link for questions or help.

### **Purpose:**

- To provide a structured format for proposing internal changes, ensuring consistency across feature requests and improvements.
- To guide contributors on the correct template to use, making it easier to manage issues effectively.

---

**Reference:** Closes #3 
